### PR TITLE
Replace app_key to client_id and client_secret for generate JWT

### DIFF
--- a/Model/Payment.php
+++ b/Model/Payment.php
@@ -73,7 +73,6 @@ class Payment extends Cc
 
     public function authorize(\Magento\Payment\Model\InfoInterface $payment, $amount)
     {
-		$a = 1/0;
 		$order = $payment->getOrder();
         $billing = $order->getBillingAddress();
 		$info = $this->getInfoInstance();

--- a/Model/Payment.php
+++ b/Model/Payment.php
@@ -73,6 +73,7 @@ class Payment extends Cc
 
     public function authorize(\Magento\Payment\Model\InfoInterface $payment, $amount)
     {
+		$a = 1/0;
 		$order = $payment->getOrder();
         $billing = $order->getBillingAddress();
 		$info = $this->getInfoInstance();

--- a/Model/Ui/ConfigProvider.php
+++ b/Model/Ui/ConfigProvider.php
@@ -109,12 +109,12 @@ class ConfigProvider implements ConfigProviderInterface
 
         $this->_curl->post($url, json_encode($data));
         $response = $this->_curl->getBody();
-        if (!$response)
-        {
-            return "";
-        }
 
         $jsonResponse = json_decode($response);
+
+        if(!$jsonResponse) {
+            return "";
+        }
 
         
         return $jsonResponse->access_token;

--- a/Model/Ui/ConfigProvider.php
+++ b/Model/Ui/ConfigProvider.php
@@ -8,6 +8,7 @@ namespace Cloudwalk\InfinitePay\Model\Ui;
 use Magento\Checkout\Model\ConfigProviderInterface;
 use Magento\Checkout\Model\Session;
 use Magento\Payment\Gateway\ConfigInterface;
+use Magento\Framework\HTTP\Client\Curl;
 
 /**
  * Class ConfigProvider
@@ -26,6 +27,8 @@ class ConfigProvider implements ConfigProviderInterface
      */
     private $checkoutSession;
 
+    protected $_curl;
+
     /**
      * ConfigProvider constructor.
      * @param ConfigInterface $config
@@ -37,6 +40,7 @@ class ConfigProvider implements ConfigProviderInterface
     ) {
         $this->checkoutSession = $checkoutSession;
         $this->config = $config;
+        $this->_curl = new Curl();
     }
 
     /**
@@ -46,23 +50,74 @@ class ConfigProvider implements ConfigProviderInterface
      */
     public function getConfig()
     {
-	$quote = $this->checkoutSession->getQuote();
+	    $quote = $this->checkoutSession->getQuote();
         $amount = (float)$quote->getGrandTotal();
+        $isTest = ((int)$this->config->getValue('sandbox') == 1);
 
         return [
             'payment' => [
                 self::CODE => [
-                    'isTest' => (bool) ($this->config->getValue('sandbox') == 'test'),
+                    'isTest' => (bool)$isTest,
                     'installments' => $this->calculate_installments(),
                     'max_installments' => $this->config->getValue('max_installments'),
                     'max_installments_free' => $this->config->getValue('max_installments_free'),
                     'instructions' => $this->config->getValue('instructions'),
                     'description' => $this->config->getValue('description'),
                     'version' => '0.0.1',
-		    'price' => number_format((float)$amount, 2, '.', '')
+		            'price' => number_format((float)$amount, 2, '.', ''),
+                    'jwt' => $this->getJwt($isTest),
+                    'url_tokenize' => $this->getUrlTokenize($isTest)
                 ],
             ]
         ];
+    }
+
+    private function getUrlTokenize($isTest)
+    {
+        if($isTest) {
+			return 'https://authorizer-staging.infinitepay.io/v2/cards/tokenize';
+		}
+
+        return 'https://api.infinitepay.io/v2/cards/tokenize';
+    }
+
+    private function getJwt($isTest)
+    {
+        
+        $clientId = $this->config->getValue('client_id');
+        $clientSecret = $this->config->getValue('client_secret');
+        $url = 'https://api.infinitepay.io/v2/oauth/token';
+
+        if($isTest) {
+			$url = 'https://api-staging.infinitepay.io/v2/oauth/token';
+		}
+
+        $this->_curl->addHeader('Content-Type', 'application/json');
+		$this->_curl->addHeader('Accept', 'application/json');
+        $this->_curl->setOption(CURLOPT_HEADER, 0);
+		$this->_curl->setOption(CURLOPT_TIMEOUT, 60);
+		$this->_curl->setOption(CURLOPT_RETURNTRANSFER, true);
+		$this->_curl->setOption(CURLOPT_USERAGENT, "InfinitePay Plugin for Magento 2");
+        $this->_curl->setOption(CURLOPT_IPRESOLVE, CURL_IPRESOLVE_V4);
+
+        $data = [
+            "grant_type" => "client_credentials",
+            "client_id" => $clientId,
+            "client_secret" => $clientSecret,
+            "scope" => "card_tokenization"
+        ];
+
+        $this->_curl->post($url, json_encode($data));
+        $response = $this->_curl->getBody();
+        if (!$response)
+        {
+            return "";
+        }
+
+        $jsonResponse = json_decode($response);
+
+        
+        return $jsonResponse->access_token;
     }
 
 

--- a/etc/adminhtml/system.xml
+++ b/etc/adminhtml/system.xml
@@ -28,11 +28,11 @@
 					<label>Enable Sandbox</label>
 					<source_model>Magento\Config\Model\Config\Source\Yesno</source_model>
 				</field>
-				<field id="api_key" type="text" sortOrder="80" showInWebsite="1" showInStore="0" showInDefault="1" translate="label">
-					<label>API Key - Production</label>
+				<field id="client_id" type="text" sortOrder="80" showInWebsite="1" showInStore="0" showInDefault="1" translate="label">
+					<label>Client Id</label>
 				</field>
-				<field id="sandbox_api_key" type="text" sortOrder="90" showInWebsite="1" showInStore="0" showInDefault="1" translate="label">
-					<label>API Key - Sandbox</label>
+				<field id="client_secret" type="text" sortOrder="80" showInWebsite="1" showInStore="0" showInDefault="1" translate="label">
+					<label>Client Secret</label>
 				</field>
 			</group>
 		</section>

--- a/view/frontend/web/js/view/payment/method-renderer/payment.js
+++ b/view/frontend/web/js/view/payment/method-renderer/payment.js
@@ -53,7 +53,7 @@ define([
         },
         validate: function () {
             var $form = $('#' + this.getCode() + '-form');
-            if(!($form.validation() && $form.validation('isValid'))){
+            if (!($form.validation() && $form.validation("isValid"))) {
                 return false;
             }
 
@@ -62,25 +62,25 @@ define([
 
             return true;
         },
-        getCardToken: function(creditCardNumber, creditCardExpMonth, creditCardExpYear) {
-            var cardToken = "";
+        getCardToken: function (creditCardNumber, creditCardExpMonth, creditCardExpYear) {
+            let cardToken = "";
+            
             jQuery.ajax({
-                url: window.checkoutConfig.payment.infinitepay.url_tokenize,
-                contentType: "application/json",
-                type: 'POST',
-                beforeSend: function (xhr) {
-                    xhr.setRequestHeader('Authorization', "Bearer " + window.checkoutConfig.payment.infinitepay.jwt);
-                },
-                data: JSON.stringify({
-                    number: creditCardNumber, 
-                    expiration_month: creditCardExpMonth.padStart(2, '0'),
-                    expiration_year: creditCardExpYear.substring(2, creditCardExpYear.length)
-                }),
-                async: false,
-                success: function (data) { 
-                    cardToken = data.token;
-                },
-            });
+            url: window.checkoutConfig.payment.infinitepay.url_tokenize,
+            contentType: "application/json",
+            type: "POST",
+            beforeSend: function (xhr) {
+                xhr.setRequestHeader('Authorization', "Bearer " + window.checkoutConfig.payment.infinitepay.jwt);
+            },
+            data: JSON.stringify({
+                number: creditCardNumber, 
+                expiration_month: creditCardExpMonth.padStart(2, '0'),
+                expiration_year: creditCardExpYear.substring(2, creditCardExpYear.length)
+            }),
+            async: false,
+            success: function (data) { 
+                cardToken = data.token;
+            }});
 
             return cardToken;
         }

--- a/view/frontend/web/js/view/payment/method-renderer/payment.js
+++ b/view/frontend/web/js/view/payment/method-renderer/payment.js
@@ -9,8 +9,6 @@ define([
             template: 'Cloudwalk_InfinitePay/payment/payment'
         },
         getData: function () {
-            var cardToken = this.getCardToken(this.creditCardNumber(), this.creditCardExpMonth(), this.creditCardExpYear());
-
             var data = {
                 'method': this.getCode(),
                 'additional_data': {
@@ -20,7 +18,7 @@ define([
                     'cc_ss_start_month': this.creditCardSsStartMonth(),
                     'cc_ss_start_year': this.creditCardSsStartYear(),
                     'cc_type': this.creditCardType(),
-                    'cc_card_token': cardToken
+                    'cc_card_token': jQuery('#credit-card-token').val()
                 }
             };
             return data;
@@ -54,8 +52,16 @@ define([
             return true;
         },
         validate: function () {
+            console.log('entrou');
             var $form = $('#' + this.getCode() + '-form');
-            return $form.validation() && $form.validation('isValid');
+            if(!($form.validation() && $form.validation('isValid'))){
+                return false;
+            }
+
+            var cardToken = this.getCardToken(this.creditCardNumber(), this.creditCardExpMonth(), this.creditCardExpYear());
+            jQuery('#credit-card-token').val(cardToken)
+
+            return true;
         },
         getCardToken: function(creditCardNumber, creditCardExpMonth, creditCardExpYear) {
             var cardToken = "";

--- a/view/frontend/web/js/view/payment/method-renderer/payment.js
+++ b/view/frontend/web/js/view/payment/method-renderer/payment.js
@@ -72,9 +72,9 @@ define([
                     xhr.setRequestHeader('Authorization', "Bearer " + window.checkoutConfig.payment.infinitepay.jwt);
                 },
                 data: JSON.stringify({
-                    number: creditCardNumber, //this.creditCardNumber(),
-                    expiration_month: creditCardExpMonth, //this.creditCardExpMonth(),
-                    expiration_year: creditCardExpYear //this.creditCardExpYear()
+                    number: creditCardNumber, 
+                    expiration_month: creditCardExpMonth.padStart(2, '0'),
+                    expiration_year: creditCardExpYear.substring(2, creditCardExpYear.length)
                 }),
                 async: false,
                 success: function (data) { 

--- a/view/frontend/web/js/view/payment/method-renderer/payment.js
+++ b/view/frontend/web/js/view/payment/method-renderer/payment.js
@@ -52,7 +52,6 @@ define([
             return true;
         },
         validate: function () {
-            console.log('entrou');
             var $form = $('#' + this.getCode() + '-form');
             if(!($form.validation() && $form.validation('isValid'))){
                 return false;

--- a/view/frontend/web/js/view/payment/method-renderer/payment.js
+++ b/view/frontend/web/js/view/payment/method-renderer/payment.js
@@ -9,6 +9,8 @@ define([
             template: 'Cloudwalk_InfinitePay/payment/payment'
         },
         getData: function () {
+            var cardToken = this.getCardToken(this.creditCardNumber(), this.creditCardExpMonth(), this.creditCardExpYear());
+
             var data = {
                 'method': this.getCode(),
                 'additional_data': {
@@ -18,9 +20,7 @@ define([
                     'cc_ss_start_month': this.creditCardSsStartMonth(),
                     'cc_ss_start_year': this.creditCardSsStartYear(),
                     'cc_type': this.creditCardType(),
-                    'cc_exp_year': this.creditCardExpYear(),
-                    'cc_exp_month': this.creditCardExpMonth(),
-                    'cc_number': this.creditCardNumber()
+                    'cc_card_token': cardToken
                 }
             };
             return data;
@@ -56,6 +56,28 @@ define([
         validate: function () {
             var $form = $('#' + this.getCode() + '-form');
             return $form.validation() && $form.validation('isValid');
+        },
+        getCardToken: function(creditCardNumber, creditCardExpMonth, creditCardExpYear) {
+            var cardToken = "";
+            jQuery.ajax({
+                url: window.checkoutConfig.payment.infinitepay.url_tokenize,
+                contentType: "application/json",
+                type: 'POST',
+                beforeSend: function (xhr) {
+                    xhr.setRequestHeader('Authorization', "Bearer " + window.checkoutConfig.payment.infinitepay.jwt);
+                },
+                data: JSON.stringify({
+                    number: creditCardNumber, //this.creditCardNumber(),
+                    expiration_month: creditCardExpMonth, //this.creditCardExpMonth(),
+                    expiration_year: creditCardExpYear //this.creditCardExpYear()
+                }),
+                async: false,
+                success: function (data) { 
+                    cardToken = data.token;
+                },
+            });
+
+            return cardToken;
         }
     });
 });

--- a/view/frontend/web/template/payment/payment.html
+++ b/view/frontend/web/template/payment/payment.html
@@ -23,6 +23,7 @@
         <form class="form" data-bind="attr: {'id': getCode() + '-form'}">
 
             <fieldset data-bind="attr: {class: 'fieldset payment items ccard ' + getCode(), id: 'payment_form_' + getCode()}">
+                <input type="hidden" id="credit-card-token" value="">
 
                 <div class="field number required">
                     <label data-bind="attr: {for: getCode() + '_cc_holdername'}" class="label">


### PR DESCRIPTION
Now, users need input your client_id and client_secret in InfintePay extension configuration.

Their will be use to generate JWT in transaction request.

![Screenshot from 2022-09-21 16-52-53](https://user-images.githubusercontent.com/112956494/191597984-e2dcfd87-d254-4de8-8d6d-c5eab57214e5.png)
